### PR TITLE
Use of String instead of constant for global flag

### DIFF
--- a/app/code/community/Comvos/ExtraCategoryTitle/sql/extracategorytitle_setup/mysql4-install-1.0.0.php
+++ b/app/code/community/Comvos/ExtraCategoryTitle/sql/extracategorytitle_setup/mysql4-install-1.0.0.php
@@ -16,7 +16,7 @@ $this->addAttribute('catalog_category', 'extra_category_title', array(
     'type'              => 'varchar',
     'label'             => 'Alternative Title',
     'input'             => 'text',
-    'global'            => 'Mage_Catalog_Model_Resource_Eav_Attribute::SCOPE_STORE',
+    'global'            => Mage_Catalog_Model_Resource_Eav_Attribute::SCOPE_STORE,
     'visible'           => true,
     'required'          => false,
     'unique'            => false,


### PR DESCRIPTION
There is a typo in mysql4-install-1.0.0.php, the constant Mage_Catalog_Model_Resource_Eav_Attribute::SCOPE_STORE is written as a string
